### PR TITLE
Add LLaTiSA time-series VLM reasoning example

### DIFF
--- a/examples/analytical/time_series/llatisa/.gitignore
+++ b/examples/analytical/time_series/llatisa/.gitignore
@@ -1,0 +1,9 @@
+artifacts/
+data/
+__pycache__/
+*.pyc
+*.pth
+*.pt
+*.npz
+checkpoints/
+.ipynb_checkpoints/

--- a/examples/analytical/time_series/llatisa/Dockerfile
+++ b/examples/analytical/time_series/llatisa/Dockerfile
@@ -1,0 +1,17 @@
+FROM pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN --mount=type=cache,mode=0777,target=/var/cache/apt apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
+    pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+COPY . .
+CMD ["bash"]

--- a/examples/analytical/time_series/llatisa/README.md
+++ b/examples/analytical/time_series/llatisa/README.md
@@ -1,0 +1,139 @@
+# LLaTiSA: VLM Time-Series Reasoning
+
+VLM-based time series reasoning using dual-view input following the
+[LLaTiSA](https://arxiv.org/abs/2604.17295) approach (ACL 2026 Findings).
+
+## Why LLaTiSA?
+
+Existing time series analysis methods treat numerical data in isolation.
+LLaTiSA bridges qualitative visual perception with quantitative numerical
+precision by feeding a Vision Language Model **two views** of the same
+series: a line plot and a precision-calibrated numerical table rendered as
+an image. This dual-view input enables chain-of-thought reasoning over
+temporal patterns at multiple cognitive levels.
+
+## What is LLaTiSA?
+
+LLaTiSA (Language-guided Time-Series Analysis) combines:
+
+1. **Line plot** -- captures visual patterns (trend, seasonality, anomalies)
+2. **Numerical table image** -- provides exact index-value pairs for
+   quantitative precision
+3. **VLM backbone** (Qwen2.5-VL) -- performs chain-of-thought reasoning
+   over both views
+
+The original paper defines four reasoning levels:
+
+| Level | Task | Description |
+|-------|------|-------------|
+| L1 | Numerical Read-out | Point-level retrieval, min/max, indexing |
+| L2 | Pattern Perception | Trend, seasonality, change-point detection |
+| L3 | Semantic Reasoning | Domain-specific interpretation |
+| L4 | Predictive Inference | Forecasting |
+
+## Quick Start
+
+```bash
+# Build
+bash build.sh
+
+# Run with synthetic data (images + VLM reasoning)
+bash infer.sh
+
+# Generate images only (no GPU required for this step)
+bash infer.sh --images-only
+
+# Ask a specific question
+bash infer.sh --question "What is the period of the seasonal component?"
+
+# Use a preset question type
+bash infer.sh --question-preset l1_minmax
+
+# Use your own data
+bash infer.sh --input /path/to/series.json
+bash infer.sh --input /path/to/data.csv --csv-column temperature
+```
+
+## Input Formats
+
+**JSON** -- either a plain array or a dict with a `"timeseries"` key:
+
+```json
+[1.0, 2.3, 1.5, 3.7, 2.1]
+```
+
+```json
+{"timeseries": [[1.0, 2.0], [1.5, 2.5], [1.2, 2.8]]}
+```
+
+**CSV** -- any CSV file; specify the column with `--csv-column`:
+
+```bash
+bash infer.sh --input data.csv --csv-column 1        # by index
+bash infer.sh --input data.csv --csv-column temperature  # by name
+```
+
+If no input is provided, a synthetic series with trend, seasonality, and
+an anomaly spike is generated.
+
+## Command-Line Options
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--input` | *(synthetic)* | Path to JSON or CSV time series file |
+| `--csv-column` | `1` | Column index or name for CSV input |
+| `--model` | `Qwen/Qwen2.5-VL-7B-Instruct` | HuggingFace model ID or local path |
+| `--question` | *(preset)* | Custom question to ask about the series |
+| `--question-preset` | `l2_trend` | Preset: `l1_minmax`, `l1_read`, `l2_trend`, `l3_anomaly` |
+| `--max-new-tokens` | `1024` | Maximum tokens in VLM response |
+| `--output-dir` | `./artifacts` | Directory for output images and results |
+| `--device` | `auto` | Device map: `auto`, `cuda`, `cpu` |
+| `--series-length` | `200` | Length of synthetic series |
+| `--seed` | `42` | Random seed for synthetic data |
+| `--images-only` | `false` | Generate images without running VLM |
+
+## Output
+
+Results are saved to `artifacts/`:
+
+- `plot.png` -- line plot visualization
+- `numeric_table.png` -- index-value table image
+- `result.json` -- question, response, and series metadata
+
+## GPU Memory
+
+The default model (Qwen2.5-VL-7B-Instruct) requires approximately 16 GB
+of GPU memory with automatic mixed precision. On a 24 GB GPU (A10/A5000),
+this runs comfortably. For lower-memory GPUs, consider using a smaller
+model variant or adding `--device cpu` (slow but functional).
+
+## Model Options
+
+This example defaults to **Qwen2.5-VL-7B-Instruct** as the VLM backbone.
+When LLaTiSA fine-tuned checkpoints become available, point `--model` to
+the checkpoint path for improved time-series reasoning performance.
+
+Other compatible models:
+
+```bash
+# Smaller variant (less GPU memory)
+bash infer.sh --model Qwen/Qwen2.5-VL-2B-Instruct
+
+# Larger variant (better reasoning)
+bash infer.sh --model Qwen/Qwen2.5-VL-72B-Instruct
+```
+
+## References
+
+- Ding et al., "LLaTiSA: Towards Difficulty-Stratified Time Series
+  Reasoning from Visual Perception to Semantics", ACL 2026 Findings.
+  [arXiv:2604.17295](https://arxiv.org/abs/2604.17295)
+- [LLaTiSA source code](https://github.com/RainingNovember/LLaTiSA)
+- [HiTSR dataset](https://huggingface.co/datasets/November-Rain/HiTSR)
+- [Qwen2.5-VL](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct)
+
+## Related Examples
+
+- `chronos_zero_shot` -- zero-shot time series forecasting
+- `moirai_zero_shot` -- foundation model zero-shot forecasting
+- `patchtst_supervised` -- supervised patch-based transformer training

--- a/examples/analytical/time_series/llatisa/build.sh
+++ b/examples/analytical/time_series/llatisa/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_NAME="${CVL_IMAGE:-analytical_llatisa}"
+
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+
+echo "Built image $IMAGE_NAME"

--- a/examples/analytical/time_series/llatisa/example.yaml
+++ b/examples/analytical/time_series/llatisa/example.yaml
@@ -1,0 +1,48 @@
+name: llatisa
+capability: analytical/time_series/reasoning
+modalities:
+  - time_series
+  - vision_language
+datasets:
+  - HiTSR
+stability: experimental
+resources:
+  gpu: 1
+  cpu_cores: 4
+  disk_gb: 20
+presets:
+  build:
+    script: build.sh
+    description: "Build the container image"
+  infer:
+    script: infer.sh
+    description: "Run dual-view VLM reasoning on a time series"
+  infer-synthetic:
+    script: infer.sh
+    args: --series-length 200 --question-preset l2_trend
+    description: "Run reasoning on a synthetic time series"
+  infer-minmax:
+    script: infer.sh
+    args: --question-preset l1_minmax
+    description: "Run min/max value extraction on a synthetic series"
+  images-only:
+    script: infer.sh
+    args: --images-only
+    description: "Generate dual-view images without VLM inference"
+tags:
+  - vlm
+  - time-series-reasoning
+  - chain-of-thought
+  - multimodal
+  - qwen-vl
+  - llatisa
+tasks:
+  - reasoning
+  - time_series_analysis
+frameworks:
+  - pytorch
+  - transformers
+description: >-
+  VLM-based time series reasoning using dual-view input (line plot +
+  numerical table) following the LLaTiSA approach for chain-of-thought
+  temporal analysis.

--- a/examples/analytical/time_series/llatisa/infer.py
+++ b/examples/analytical/time_series/llatisa/infer.py
@@ -1,0 +1,456 @@
+"""LLaTiSA: VLM-based time series reasoning with dual-view input.
+
+Renders a time series as both a line plot and a precision-calibrated
+numerical table, then feeds both images to a Vision Language Model for
+chain-of-thought reasoning over the series.
+
+Reference:
+  Ding et al., "LLaTiSA: Towards Difficulty-Stratified Time Series
+  Reasoning from Visual Perception to Semantics", ACL 2026 Findings.
+  https://arxiv.org/abs/2604.17295
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Dual-view image generation
+# ---------------------------------------------------------------------------
+
+def render_line_plot(
+    series: np.ndarray,
+    out_path: str | Path,
+    title: str = "Time Series",
+    dpi: int = 150,
+) -> Path:
+    """Render a line plot of one or more univariate series.
+
+    Args:
+        series: Array of shape (T,) or (T, D) where T is time steps, D dimensions.
+        out_path: Destination PNG path.
+        title: Plot title.
+        dpi: Resolution.
+
+    Returns:
+        The output path.
+    """
+    out_path = Path(out_path)
+    series = np.asarray(series, dtype=float)
+    if series.ndim == 1:
+        series = series[:, None]
+    T, D = series.shape
+
+    fig, axes = plt.subplots(D, 1, figsize=(10, max(3 * D, 4)), squeeze=False)
+    for i in range(D):
+        ax = axes[i, 0]
+        ax.plot(range(T), series[:, i], color="blue", linewidth=1.2)
+        ax.set_xlabel("Time Step")
+        ax.set_ylabel(f"Dim {i}" if D > 1 else "Value")
+        ax.grid(True, alpha=0.3)
+    axes[0, 0].set_title(title)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def render_numeric_table(
+    series: np.ndarray,
+    out_path: str | Path,
+    rows_per_block: int = 50,
+    dpi: int = 150,
+) -> Path:
+    """Render a high-precision index-value table as an image.
+
+    The table shows each time index alongside its value(s) formatted with
+    full double-precision fidelity, mirroring the approach from the LLaTiSA
+    paper that bridges qualitative visual perception with quantitative
+    numerical precision.
+
+    Args:
+        series: Array of shape (T,) or (T, D).
+        out_path: Destination PNG path.
+        rows_per_block: Maximum rows per column block.
+        dpi: Resolution.
+
+    Returns:
+        The output path.
+    """
+    out_path = Path(out_path)
+    series = np.asarray(series, dtype=float)
+    if series.ndim == 1:
+        series = series[:, None]
+    T, D = series.shape
+
+    def fmt(v: float) -> str:
+        return f"{v:.6g}"
+
+    # Build text lines: "idx | v0 | v1 | ..."
+    header_parts = ["Index"] + [f"Dim{d}" if D > 1 else "Value" for d in range(D)]
+    header = "  ".join(f"{h:>12s}" for h in header_parts)
+    lines = [header, "-" * len(header)]
+    for t in range(T):
+        parts = [f"{t:>12d}"] + [f"{fmt(series[t, d]):>12s}" for d in range(D)]
+        lines.append("  ".join(parts))
+
+    # Split into blocks for wide rendering
+    n_blocks = max(1, (T + rows_per_block - 1) // rows_per_block)
+    block_lines: list[list[str]] = []
+    for b in range(n_blocks):
+        start = b * rows_per_block
+        end = min(start + rows_per_block, T)
+        block = [lines[0], lines[1]] + lines[2 + start : 2 + end]
+        block_lines.append(block)
+
+    # Render as image using matplotlib text
+    fig_width = 6 * n_blocks
+    fig_height = max(4, 0.18 * (rows_per_block + 2))
+    fig, axes = plt.subplots(
+        1, n_blocks, figsize=(fig_width, fig_height), squeeze=False
+    )
+    for b, block in enumerate(block_lines):
+        ax = axes[0, b]
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, len(block))
+        ax.axis("off")
+        for row_idx, line in enumerate(block):
+            y = len(block) - 1 - row_idx
+            bg = "#f0f0f0" if row_idx % 2 == 0 else "#ffffff"
+            ax.axhspan(y, y + 1, color=bg, zorder=0)
+            ax.text(
+                0.02,
+                y + 0.5,
+                line,
+                fontsize=7,
+                fontfamily="monospace",
+                verticalalignment="center",
+                zorder=1,
+            )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = (
+    "You are a time-series reasoning assistant. You are given two images of "
+    "the same time series: a line plot showing visual patterns, and a "
+    "numerical table with precise index-value pairs. Use both views to "
+    "answer the question. Think step by step."
+)
+
+EXAMPLE_QUESTIONS = {
+    "l1_minmax": (
+        "What is the maximum value in this time series, and at which "
+        "time step does it occur? Also report the minimum value and its "
+        "time step."
+    ),
+    "l1_read": (
+        "What is the value of this time series at time step {idx}?"
+    ),
+    "l2_trend": (
+        "Describe the overall trend of this time series. Is it increasing, "
+        "decreasing, stationary, or does it exhibit a more complex pattern? "
+        "Identify any notable local patterns such as peaks, troughs, or "
+        "change points."
+    ),
+    "l3_anomaly": (
+        "Analyze this time series for anomalies. Are there any unusual "
+        "spikes, drops, or deviations from the expected pattern? If so, "
+        "at which time steps do they occur, and what might explain them?"
+    ),
+}
+
+
+def build_messages(
+    plot_path: Path,
+    table_path: Path,
+    question: str,
+) -> list[dict]:
+    """Build a multi-image chat message list for the VLM."""
+    return [
+        {"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Here is the line plot of the time series:"},
+                {"type": "image", "image": f"file://{plot_path.resolve()}"},
+                {
+                    "type": "text",
+                    "text": (
+                        "Here is the numerical table with precise index-value "
+                        "pairs for the same series:"
+                    ),
+                },
+                {"type": "image", "image": f"file://{table_path.resolve()}"},
+                {"type": "text", "text": question},
+            ],
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# VLM inference
+# ---------------------------------------------------------------------------
+
+def run_inference(
+    messages: list[dict],
+    model_path: str,
+    max_new_tokens: int = 1024,
+    device: str = "auto",
+) -> str:
+    """Run inference with Qwen2.5-VL / Qwen3-VL."""
+    from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor
+    from qwen_vl_utils import process_vision_info
+
+    print(f"Loading model from {model_path} ...", flush=True)
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        model_path,
+        torch_dtype="auto",
+        device_map=device,
+    )
+    processor = AutoProcessor.from_pretrained(model_path)
+
+    text = processor.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    image_inputs, video_inputs = process_vision_info(messages)
+    inputs = processor(
+        text=[text],
+        images=image_inputs,
+        videos=video_inputs,
+        padding=True,
+        return_tensors="pt",
+    ).to(model.device)
+
+    print("Generating response ...", flush=True)
+    output_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
+    # Trim the prompt tokens from the output
+    generated_ids = output_ids[:, inputs.input_ids.shape[1] :]
+    response = processor.batch_decode(
+        generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
+    )[0]
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Data loading helpers
+# ---------------------------------------------------------------------------
+
+def load_series_from_json(path: str) -> np.ndarray:
+    """Load a time series from a JSON file.
+
+    Accepts either a plain array ``[1.0, 2.0, ...]`` or a dict with a
+    ``"timeseries"`` key (HiTSR format).
+    """
+    with open(path) as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        ts = data.get("timeseries", data.get("values", data.get("data")))
+    else:
+        ts = data
+    return np.asarray(ts, dtype=float)
+
+
+def load_series_from_csv(path: str, column: int | str = 1) -> np.ndarray:
+    """Load a time series column from a CSV file."""
+    import pandas as pd
+
+    df = pd.read_csv(path)
+    if isinstance(column, int):
+        return df.iloc[:, column].values.astype(float)
+    return df[column].values.astype(float)
+
+
+def generate_synthetic_series(length: int = 200, seed: int = 42) -> np.ndarray:
+    """Generate a synthetic time series with trend, seasonality, and noise."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(length, dtype=float)
+    trend = 0.02 * t
+    seasonal = 2.0 * np.sin(2 * np.pi * t / 50)
+    noise = rng.normal(0, 0.3, size=length)
+    # Add an anomaly spike
+    anomaly_idx = int(length * 0.7)
+    noise[anomaly_idx] += 5.0
+    return trend + seasonal + noise
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="LLaTiSA: VLM time-series reasoning with dual-view input",
+    )
+    p.add_argument(
+        "--input",
+        type=str,
+        default=None,
+        help="Path to input time series (JSON or CSV). Uses synthetic data if omitted.",
+    )
+    p.add_argument(
+        "--csv-column",
+        type=str,
+        default="1",
+        help="Column index (int) or name (str) for CSV input. Default: 1.",
+    )
+    p.add_argument(
+        "--model",
+        type=str,
+        default="Qwen/Qwen2.5-VL-7B-Instruct",
+        help="HuggingFace model ID or local path. Default: Qwen/Qwen2.5-VL-7B-Instruct.",
+    )
+    p.add_argument(
+        "--question",
+        type=str,
+        default=None,
+        help="Custom question to ask about the series. If omitted, a default question is used.",
+    )
+    p.add_argument(
+        "--question-preset",
+        type=str,
+        choices=list(EXAMPLE_QUESTIONS.keys()),
+        default="l2_trend",
+        help="Preset question type. Ignored if --question is given.",
+    )
+    p.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=1024,
+        help="Maximum tokens in VLM response.",
+    )
+    p.add_argument(
+        "--output-dir",
+        type=str,
+        default="./artifacts",
+        help="Directory for output images and results.",
+    )
+    p.add_argument(
+        "--device",
+        type=str,
+        default="auto",
+        help="Device map for model loading (auto, cuda, cpu).",
+    )
+    p.add_argument(
+        "--series-length",
+        type=int,
+        default=200,
+        help="Length of synthetic series (only used when --input is omitted).",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for synthetic data.",
+    )
+    p.add_argument(
+        "--images-only",
+        action="store_true",
+        help="Only generate dual-view images, skip VLM inference.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Load or generate series ---
+    if args.input is not None:
+        input_path = args.input
+        print(f"Loading time series from {input_path} ...", flush=True)
+        if input_path.endswith(".csv"):
+            try:
+                col = int(args.csv_column)
+            except ValueError:
+                col = args.csv_column
+            series = load_series_from_csv(input_path, column=col)
+        else:
+            series = load_series_from_json(input_path)
+    else:
+        print(
+            f"No input provided; generating synthetic series "
+            f"(length={args.series_length}, seed={args.seed}) ...",
+            flush=True,
+        )
+        series = generate_synthetic_series(
+            length=args.series_length, seed=args.seed
+        )
+
+    print(
+        f"Series shape: {series.shape}, "
+        f"range: [{series.min():.4f}, {series.max():.4f}]",
+        flush=True,
+    )
+
+    # --- Generate dual-view images ---
+    plot_path = render_line_plot(series, out_dir / "plot.png")
+    table_path = render_numeric_table(series, out_dir / "numeric_table.png")
+    print(f"Saved line plot:       {plot_path}", flush=True)
+    print(f"Saved numeric table:   {table_path}", flush=True)
+
+    if args.images_only:
+        print("Images-only mode; skipping VLM inference.", flush=True)
+        return
+
+    # --- Build question ---
+    if args.question:
+        question = args.question
+    else:
+        question = EXAMPLE_QUESTIONS[args.question_preset]
+        # Fill in template placeholders if any
+        if "{idx}" in question:
+            idx = len(series) // 2
+            question = question.format(idx=idx)
+
+    print(f"\nQuestion: {question}\n", flush=True)
+
+    # --- Run VLM inference ---
+    messages = build_messages(plot_path, table_path, question)
+    response = run_inference(
+        messages,
+        model_path=args.model,
+        max_new_tokens=args.max_new_tokens,
+        device=args.device,
+    )
+
+    print("=" * 60)
+    print("RESPONSE:")
+    print("=" * 60)
+    print(response)
+    print("=" * 60)
+
+    # --- Save results ---
+    result = {
+        "model": args.model,
+        "question": question,
+        "response": response,
+        "series_shape": list(series.shape),
+        "series_range": [float(series.min()), float(series.max())],
+    }
+    result_path = out_dir / "result.json"
+    with open(result_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"\nResults saved to {result_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/analytical/time_series/llatisa/infer.sh
+++ b/examples/analytical/time_series/llatisa/infer.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+IMG="${CVL_IMAGE:-analytical_llatisa}"
+CONTAINER_NAME="${CVL_CONTAINER_NAME:-}"
+HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
+
+mkdir -p "$HF_CACHE" "$SCRIPT_DIR/artifacts"
+
+# Load .env if present
+if [[ -f "$REPO_ROOT/.env" ]]; then
+    echo "Loading defaults from $REPO_ROOT/.env" >&2
+    set -a
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/.env"
+    set +a
+fi
+
+DOCKER_ARGS=(
+    "--rm"
+    "--shm-size" "16G"
+    "--workdir" "/workspace"
+    "--mount" "type=bind,src=${SCRIPT_DIR},dst=/workspace"
+    "--mount" "type=bind,src=${HF_CACHE},dst=/root/.cache/huggingface"
+    "--env" "PYTHONUNBUFFERED=1"
+    "--env" "HF_HOME=/root/.cache/huggingface"
+)
+
+[[ -n "$CONTAINER_NAME" ]] && DOCKER_ARGS+=("--name" "$CONTAINER_NAME")
+[[ "${CVL_ENABLE_GPU:-1}" == "1" ]] && DOCKER_ARGS+=("--gpus" "all")
+[[ -n "${HF_TOKEN:-}" ]] && DOCKER_ARGS+=("--env" "HF_TOKEN=${HF_TOKEN}")
+
+DOCKER_ARGS+=("$IMG" "python" "infer.py")
+
+# Forward all script arguments to the Python script
+for arg in "$@"; do DOCKER_ARGS+=("$arg"); done
+
+docker run "${DOCKER_ARGS[@]}"

--- a/examples/analytical/time_series/llatisa/requirements.txt
+++ b/examples/analytical/time_series/llatisa/requirements.txt
@@ -1,0 +1,8 @@
+torch==2.4.0
+transformers==4.49.0
+accelerate==1.3.0
+qwen-vl-utils==0.0.8
+numpy==1.26.4
+matplotlib==3.9.2
+pandas==2.2.3
+Pillow==10.4.0


### PR DESCRIPTION
## Summary
- Adds a new dockerized inference example at `examples/analytical/time_series/llatisa/` implementing the dual-view input approach from the LLaTiSA paper (ACL 2026 Findings, [arXiv:2604.17295](https://arxiv.org/abs/2604.17295))
- Renders time series as both a **line plot** (visual patterns) and a **precision-calibrated numerical table** (exact index-value pairs), then feeds both images to a Vision Language Model (Qwen2.5-VL) for chain-of-thought reasoning
- Supports JSON/CSV input, preset question types spanning L1-L3 reasoning levels, and an images-only mode for generating dual-view visualizations without VLM inference

## Test plan
- [x] Docker image builds successfully
- [x] Images-only mode generates both plot and numeric table images
- [x] Full VLM inference pipeline runs end-to-end with synthetic data
- [ ] Test with real-world CSV time series input
- [ ] Test with HiTSR dataset samples

Closes #12