### PR TITLE
Add GLM-5V-Turbo multimodal agent VLM example

### DIFF
--- a/examples/perception/vision_language/glm5v_turbo/.gitignore
+++ b/examples/perception/vision_language/glm5v_turbo/.gitignore
@@ -1,0 +1,39 @@
+# Outputs
+outputs/
+*.json
+*.txt
+results/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+
+# Images (keep shared examples but ignore large dumps)
+*.jpg
+*.jpeg
+*.png
+*.pdf
+!examples/*.jpg
+!examples/*.jpeg
+!examples/*.png

--- a/examples/perception/vision_language/glm5v_turbo/Dockerfile
+++ b/examples/perception/vision_language/glm5v_turbo/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+COPY requirements.txt .
+RUN /root/.local/bin/uv pip install --system -r requirements.txt
+
+WORKDIR /workspace
+
+CMD ["python3", "predict.py"]

--- a/examples/perception/vision_language/glm5v_turbo/README.md
+++ b/examples/perception/vision_language/glm5v_turbo/README.md
@@ -1,0 +1,84 @@
+# GLM-5V-Turbo (Z.ai API)
+
+Multimodal agent VLM from Z.ai. GLM-5V-Turbo integrates visual perception as a core component of reasoning, planning, and tool use -- positioned as a native foundation model for multimodal agents rather than a vision module bolted onto a language model.
+
+## Highlights
+
+- **Model**: `glm-5v-turbo` via Z.ai API (OpenAI-compatible)
+- **Tasks**: captioning, OCR, VQA, GUI grounding, visual reasoning
+- **No GPU required**: runs via API, lightweight Docker image
+- **Agent-oriented**: designed for GUI grounding, visual tool use, multimodal coding
+
+## Setup
+
+Get an API key from [Z.ai Open Platform](https://open.z.ai), then:
+
+```bash
+export ZAI_API_KEY="your-key-here"
+```
+
+## Quick Start
+
+```bash
+cd examples/perception/vision_language/glm5v_turbo
+
+# Build the Docker image
+bash build.sh
+
+# Caption an image
+bash predict.sh --image test_images/sample.jpg --task caption
+
+# GUI grounding on a screenshot
+bash predict.sh --image screenshot.png --task gui_grounding
+
+# Visual reasoning with step-by-step thinking
+bash predict.sh --image diagram.png --task reasoning --thinking
+
+# VQA with custom prompt
+bash predict.sh --image chart.png --task vqa --prompt "What trend is shown?"
+
+# Multi-image input
+bash predict.sh --images page1.png page2.png --task ocr
+```
+
+## CVL CLI Presets
+
+```bash
+cvl run glm5v_turbo build
+cvl run glm5v_turbo predict --image test_images/sample.jpg --task caption
+cvl run glm5v_turbo test
+```
+
+## Script Arguments
+
+```
+python predict.py \
+  [--image path|url]                # single image
+  [--images p1 p2 ...]             # multi-image
+  [--task caption|ocr|vqa|gui_grounding|reasoning]
+  [--prompt "question"]            # required for vqa
+  [--max-tokens N]                 # default: 1024
+  [--temperature T]                # default: 0.2
+  [--thinking]                     # enable step-by-step reasoning
+  [--output outputs/result.txt]
+  [--format txt|json]
+  [--api-key KEY]                  # or set ZAI_API_KEY
+  [--base-url URL]                 # override API endpoint
+```
+
+## Notes
+
+- GLM-5V-Turbo does not have open-source weights. Inference runs via the Z.ai cloud API.
+- The Z.ai API is OpenAI-compatible, so this example uses the `openai` Python package with a custom `base_url`.
+- No GPU or HuggingFace cache is needed since the model runs server-side.
+- GUI grounding and visual tool use are the distinguishing capabilities vs other VLMs in CVlization (gemma3_vision, qwen3_vl, etc.).
+
+## References
+
+- [GLM-5V-Turbo paper](https://huggingface.co/papers/2604.26752)
+- [Z.ai API docs](https://docs.z.ai/guides/vlm/glm-5v-turbo)
+- [GLM-V GitHub](https://github.com/zai-org/GLM-V)
+
+## License
+
+API usage is subject to Z.ai's terms of service. This example script is MIT, consistent with the rest of CVlization.

--- a/examples/perception/vision_language/glm5v_turbo/build.sh
+++ b/examples/perception/vision_language/glm5v_turbo/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from this folder
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build -t glm5v-turbo "$SCRIPT_DIR"

--- a/examples/perception/vision_language/glm5v_turbo/example.yaml
+++ b/examples/perception/vision_language/glm5v_turbo/example.yaml
@@ -1,0 +1,58 @@
+name: glm5v-turbo
+capability: perception/vision_language
+modalities:
+  - vision
+  - text
+stability: experimental
+resources:
+  gpu: 0
+  vram_gb: 0
+  disk_gb: 1
+image: glm5v-turbo
+presets:
+  build:
+    script: build.sh
+    description: Build Docker image (lightweight, no GPU required)
+  predict:
+    script: predict.sh
+    description: Run inference via Z.ai API
+    path_args:
+      - flag: "--image"
+        type: file
+      - flag: "--images"
+        type: file
+      - flag: "--output"
+        type: file
+  test:
+    script: test.sh
+    description: Smoke test (requires ZAI_API_KEY)
+tags:
+  - glm
+  - vlm
+  - zai
+  - zhipu
+  - agent
+  - gui-grounding
+  - visual-tool-use
+  - multimodal-agent
+  - api-based
+tasks:
+  - image_captioning
+  - ocr
+  - visual_question_answering
+  - visual_reasoning
+  - gui_grounding
+frameworks:
+  - openai-compatible-api
+description: >
+  GLM-5V-Turbo multimodal agent VLM via the Z.ai API.
+  A native foundation model for multimodal agents with integrated
+  perception, reasoning, planning, and tool use. Supports GUI grounding,
+  visual tool use, multimodal coding, and deep visual reasoning.
+  API-based -- no local GPU required.
+
+verification:
+  last_verified: "2026-05-05"
+  last_verification_note: >
+    Initial implementation. API-based inference using OpenAI-compatible
+    Z.ai endpoint. No open weights available -- model is accessed via API.

--- a/examples/perception/vision_language/glm5v_turbo/predict.py
+++ b/examples/perception/vision_language/glm5v_turbo/predict.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+GLM-5V-Turbo inference runner via the Z.ai API.
+
+GLM-5V-Turbo is a native multimodal agent foundation model from Z.ai,
+designed for visual reasoning, GUI grounding, visual tool use, and
+multimodal coding. Unlike standard VLMs that bolt vision onto a text
+model, GLM-5V-Turbo integrates multimodal perception as a core part
+of reasoning, planning, and execution.
+
+This example uses the Z.ai API (OpenAI-compatible) -- no local GPU required.
+
+Usage examples:
+  # Caption an image
+  python predict.py --image test_images/sample.jpg --task caption
+
+  # GUI grounding on a screenshot
+  python predict.py --image screenshot.png --task gui_grounding
+
+  # Visual reasoning with thinking mode
+  python predict.py --image diagram.png --task reasoning --thinking
+
+  # Custom prompt
+  python predict.py --image chart.png --task vqa --prompt "What trend is visible?"
+
+Requires:
+  ZAI_API_KEY environment variable (get one at https://open.z.ai)
+"""
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from openai import OpenAI
+
+from cvlization.paths import resolve_input_path, resolve_output_path
+
+# Z.ai API endpoint (OpenAI-compatible)
+DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
+MODEL_ID = "glm-5v-turbo"
+
+TASK_PROMPTS = {
+    "caption": "Describe this image in detail.",
+    "ocr": "Extract all text from this image. Preserve the layout as closely as possible.",
+    "vqa": None,  # requires --prompt
+    "gui_grounding": (
+        "Identify all interactive UI elements in this screenshot. "
+        "For each element, describe its type (button, text field, checkbox, etc.), "
+        "its label or text content, and its approximate location in the image."
+    ),
+    "reasoning": (
+        "Analyze this image step by step. Describe what you observe, "
+        "identify key elements, and explain any relationships, patterns, "
+        "or conclusions you can draw."
+    ),
+}
+
+
+def encode_image_to_base64(image_path: str) -> str:
+    with open(image_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def detect_mime_type(image_path: str) -> str:
+    ext = Path(image_path).suffix.lower()
+    mime_map = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".bmp": "image/bmp",
+    }
+    return mime_map.get(ext, "image/jpeg")
+
+
+def build_messages(image_paths: list, prompt: str) -> list:
+    content = []
+    for path in image_paths:
+        if path.startswith("http://") or path.startswith("https://"):
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": path},
+            })
+        else:
+            mime = detect_mime_type(path)
+            b64 = encode_image_to_base64(path)
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{b64}"},
+            })
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
+
+
+def run_inference(
+    client: OpenAI,
+    image_paths: list,
+    prompt: str,
+    max_tokens: int = 1024,
+    temperature: float = 0.2,
+    thinking: bool = False,
+) -> str:
+    messages = build_messages(image_paths, prompt)
+
+    kwargs = {
+        "model": MODEL_ID,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+
+    response = client.chat.completions.create(**kwargs)
+    return response.choices[0].message.content
+
+
+def save_output(text: str, path: Path, fmt: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fmt == "json":
+        payload = {
+            "text": text,
+            "model": MODEL_ID,
+            "timestamp": __import__("datetime").datetime.now().isoformat(),
+        }
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"Output saved to {path} (JSON)")
+    else:
+        path.write_text(text, encoding="utf-8")
+        print(f"Output saved to {path}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="GLM-5V-Turbo inference via Z.ai API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python predict.py --image test_images/sample.jpg --task caption
+  python predict.py --image screenshot.png --task gui_grounding
+  python predict.py --image chart.png --task vqa --prompt "What trend is shown?"
+  python predict.py --image diagram.png --task reasoning --thinking
+        """,
+    )
+    parser.add_argument("--image", help="Path/URL to a single image.")
+    parser.add_argument("--images", nargs="+", help="Paths/URLs to multiple images.")
+    parser.add_argument(
+        "--task",
+        choices=list(TASK_PROMPTS.keys()),
+        default="caption",
+        help="Task to run (default: caption).",
+    )
+    parser.add_argument("--prompt", help="Custom prompt (required for vqa task).")
+    parser.add_argument("--max-tokens", type=int, default=1024, help="Max output tokens (default: 1024).")
+    parser.add_argument("--output", default="result.txt", help="Output path.")
+    parser.add_argument("--format", choices=["txt", "json"], default="txt")
+    parser.add_argument("--temperature", type=float, default=0.2, help="Sampling temperature (default: 0.2).")
+    parser.add_argument(
+        "--thinking",
+        action="store_true",
+        help="Enable thinking/reasoning mode for step-by-step analysis.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("ZAI_API_KEY"),
+        help="Z.ai API key (default: ZAI_API_KEY env var).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("ZAI_BASE_URL", DEFAULT_BASE_URL),
+        help="API base URL (default: Z.ai endpoint).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not args.api_key:
+        raise SystemExit(
+            "ZAI_API_KEY is required. Set it via --api-key or the ZAI_API_KEY "
+            "environment variable.\nGet an API key at https://open.z.ai"
+        )
+    if args.task == "vqa" and not args.prompt:
+        raise SystemExit("--prompt is required for vqa task.")
+    if args.image and args.images:
+        raise SystemExit("Specify either --image or --images, not both.")
+
+    DEFAULT_IMAGE = "test_images/sample.jpg"
+    using_bundled_sample = False
+    if not args.image and not args.images:
+        args.image = DEFAULT_IMAGE
+        using_bundled_sample = True
+        print(f"No --image provided, using bundled sample: {DEFAULT_IMAGE}")
+
+    print("=" * 60)
+    print("GLM-5V-Turbo Inference (Z.ai API)")
+    print(f"Model: {MODEL_ID}")
+    print(f"Task: {args.task}")
+    print(f"Thinking: {'enabled' if args.thinking else 'disabled'}")
+    print("=" * 60)
+
+    # Resolve paths
+    if using_bundled_sample:
+        image_paths = [args.image]
+    elif args.image:
+        image_paths = [resolve_input_path(args.image)]
+    else:
+        image_paths = [resolve_input_path(p) for p in args.images]
+    output_path = Path(resolve_output_path(args.output))
+
+    prompt = args.prompt or TASK_PROMPTS[args.task]
+    if args.thinking and args.task != "reasoning":
+        prompt = f"Think step by step.\n\n{prompt}"
+
+    client = OpenAI(api_key=args.api_key, base_url=args.base_url)
+
+    print(f"\nProcessing {len(image_paths)} image(s)...")
+    response = run_inference(
+        client,
+        image_paths,
+        prompt,
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        thinking=args.thinking,
+    )
+
+    print("\n" + "=" * 60)
+    print("Result:")
+    print("=" * 60)
+    print(response)
+    print("=" * 60 + "\n")
+
+    save_output(response, output_path, args.format)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/perception/vision_language/glm5v_turbo/predict.sh
+++ b/examples/perception/vision_language/glm5v_turbo/predict.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from this folder
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="${CVL_WORK_DIR:-${WORK_DIR:-$(pwd)}}"
+
+# Find repo root for cvlization package (go up 4 levels from example dir)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Image name
+IMG="${CVL_IMAGE:-glm5v-turbo}"
+
+# GLM-5V-Turbo is API-based (no GPU required).
+# Pass ZAI_API_KEY to authenticate with Z.ai.
+docker run --rm \
+  ${CVL_CONTAINER_NAME:+--name "$CVL_CONTAINER_NAME"} \
+  --workdir /workspace \
+  --mount "type=bind,src=${SCRIPT_DIR},dst=/workspace" \
+  --mount "type=bind,src=${SCRIPT_DIR}/../test_images,dst=/workspace/test_images,readonly" \
+  --mount "type=bind,src=${REPO_ROOT},dst=/cvlization_repo,readonly" \
+  --mount "type=bind,src=${WORK_DIR},dst=/mnt/cvl/workspace" \
+  --env "PYTHONPATH=/cvlization_repo" \
+  --env "PYTHONUNBUFFERED=1" \
+  --env "ZAI_API_KEY=${ZAI_API_KEY:-}" \
+  --env "ZAI_BASE_URL=${ZAI_BASE_URL:-}" \
+  --env "CVL_INPUTS=${CVL_INPUTS:-/mnt/cvl/workspace}" \
+  --env "CVL_OUTPUTS=${CVL_OUTPUTS:-/mnt/cvl/workspace}" \
+  "$IMG" python3 predict.py "$@"

--- a/examples/perception/vision_language/glm5v_turbo/test.sh
+++ b/examples/perception/vision_language/glm5v_turbo/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${ZAI_API_KEY:-}" ]]; then
+  echo "ZAI_API_KEY is required. Set it before running tests."
+  echo "Get an API key at https://open.z.ai"
+  exit 1
+fi
+
+echo "Running GLM-5V-Turbo smoke test..."
+
+bash "$SCRIPT_DIR/predict.sh" \
+  --image test_images/sample.jpg \
+  --task caption \
+  --max-tokens 256 \
+  --output "outputs/test_caption.txt"
+
+echo "Smoke test completed successfully!"


### PR DESCRIPTION
## Summary

- Adds a new vision_language example for Z.ai's GLM-5V-Turbo, a native foundation model for multimodal agents
- API-based inference via the OpenAI-compatible Z.ai endpoint (no local GPU required)
- Supports caption, OCR, VQA, GUI grounding, and visual reasoning tasks
- Follows CVlization conventions: Dockerfile, build/predict/test scripts, example.yaml, cvlization.paths integration

## Key details

GLM-5V-Turbo does **not** have open-source weights -- it is accessed via the Z.ai cloud API. This makes it different from most other VLM examples in CVlization (gemma3_vision, qwen3_vl, internvl3, etc.) which run locally. The Docker image is lightweight (python:3.11-slim base, ~200MB) and requires a `ZAI_API_KEY` environment variable.

The agent-oriented tasks (GUI grounding, visual reasoning with thinking mode) differentiate this from existing VLM examples that focus on captioning/VQA.

## Files

- `examples/perception/vision_language/glm5v_turbo/predict.py` - Main inference script
- `examples/perception/vision_language/glm5v_turbo/Dockerfile` - Lightweight container (no GPU)
- `examples/perception/vision_language/glm5v_turbo/build.sh` / `predict.sh` / `test.sh` - Standard scripts
- `examples/perception/vision_language/glm5v_turbo/example.yaml` - CVL metadata
- `examples/perception/vision_language/glm5v_turbo/README.md` - Documentation

## Test plan

- [x] Docker image builds successfully
- [ ] Smoke test with `ZAI_API_KEY` set (requires API key)

Closes #13