### PR TITLE
Add TIDE cross-architecture distillation for diffusion LLMs

### DIFF
--- a/examples/generative/llm/tide_dllm_distill/.gitignore
+++ b/examples/generative/llm/tide_dllm_distill/.gitignore
@@ -1,0 +1,11 @@
+outputs/
+checkpoints/
+weights/
+logs/
+__pycache__/
+*.pyc
+*.pt
+*.pth
+*.bin
+*.safetensors
+.DS_Store

--- a/examples/generative/llm/tide_dllm_distill/Dockerfile
+++ b/examples/generative/llm/tide_dllm_distill/Dockerfile
@@ -1,0 +1,42 @@
+FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and install dllm (for BD3LM inference sampling)
+# Patch: guard optional imports (lm_eval, trl) that are not needed for
+# training or inference but cause ImportError if absent.
+RUN git clone https://github.com/ZHZisZZ/dllm.git /opt/dllm && \
+    cd /opt/dllm && \
+    printf '%s\n' \
+      'from . import core, utils' \
+      'for _mod in ("data", "pipelines"):' \
+      '    try:' \
+      '        __import__(f"dllm.{_mod}", fromlist=[_mod])' \
+      '    except ImportError:' \
+      '        pass' \
+      > dllm/__init__.py && \
+    printf '%s\n' \
+      'from . import samplers, schedulers, trainers' \
+      'try:' \
+      '    from . import eval' \
+      'except ImportError:' \
+      '    pass' \
+      > dllm/core/__init__.py && \
+    pip install --no-cache-dir -e .
+
+# Copy and install additional Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set working directory
+WORKDIR /workspace
+
+# Environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Default command
+CMD ["python", "train.py", "--help"]

--- a/examples/generative/llm/tide_dllm_distill/README.md
+++ b/examples/generative/llm/tide_dllm_distill/README.md
@@ -1,0 +1,103 @@
+# TIDE - Cross-Architecture Distillation for Diffusion LLMs
+
+Distill knowledge from a larger diffusion language model (teacher) into a smaller one (student) using the TIDE recipe.
+
+## Overview
+
+TIDE introduces three components for dLLM distillation:
+
+- **TIDAL** (scheduling): cosine-interpolated soft targets that gradually shift from student self-supervision to teacher guidance
+- **CompDemo** (context): complementary mask-splitting that gives the teacher ~50% more context per forward pass, improving signal quality at high masking ratios
+- **Reverse CALM** (output, Pipeline A only): gradient-stable cross-tokenizer alignment via reversed BCE
+
+This example implements **Pipeline B** (shared-tokenizer distillation with TIDAL + CompDemo). The default setup distills from WeDLM-8B-Instruct into Qwen3-0.6B-BD3LM.
+
+## Usage
+
+### Build
+
+```bash
+cvl run tide-dllm-distill build
+```
+
+### Train (distillation)
+
+```bash
+# Self-distillation (smoke test, ~5GB VRAM)
+cvl run tide-dllm-distill train
+
+# With a real teacher (~20GB VRAM)
+cvl run tide-dllm-distill train -- \
+  --teacher-model WeDLM/WeDLM-8B-Instruct \
+  --steps 10000
+
+# Custom dataset
+cvl run tide-dllm-distill train -- \
+  --dataset tatsu-lab/alpaca \
+  --max-length 512 \
+  --batch-size 4
+```
+
+### Inference
+
+```bash
+# Base (undistilled) model
+cvl run tide-dllm-distill predict
+
+# TIDE-distilled model (Pipeline B)
+cvl run tide-dllm-distill predict -- --model tide-wedlm-shared
+
+# TIDE-distilled model (Pipeline A)
+cvl run tide-dllm-distill predict -- --model tide-llada-cross
+
+# Custom prompt
+cvl run tide-dllm-distill predict -- \
+  --model tide-wedlm-shared \
+  --prompt "Write a Python function to check if a number is prime." \
+  --steps 256 \
+  --max-tokens 512
+```
+
+### Smoke test
+
+```bash
+cvl run tide-dllm-distill test
+```
+
+Runs self-distillation for 10 steps and a quick inference check.
+
+## Available Models
+
+| Key | HuggingFace ID | Description |
+|-----|---------------|-------------|
+| `base` | `dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1` | Base student (undistilled) |
+| `tide-wedlm-shared` | `TIDE-dllm/distill-WeDLM-TIDE_Shared` | Pipeline B: TIDAL + CompDemo |
+| `tide-llada-cross` | `TIDE-dllm/distill-LLaDA2-TIDE_Cross` | Pipeline A: Reverse CALM |
+
+## VRAM Requirements
+
+| Mode | VRAM |
+|------|------|
+| Inference (any 0.6B model) | ~2 GB |
+| Self-distillation (student = teacher) | ~5 GB |
+| Full distillation (8B teacher + 0.6B student) | ~20 GB |
+
+## Key Training Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--lambda-init` | 0.1 | TIDAL initial interpolation weight |
+| `--lambda-max` | 0.9 | TIDAL final interpolation weight |
+| `--temperature` | 2.0 | Softmax temperature for distillation |
+| `--ce-weight` | 1.0 | Cross-entropy loss weight |
+| `--tidal-weight` | 1.0 | TIDAL distillation loss weight |
+| `--use-comp-demo` | true | Enable Complementary Demonstration |
+| `--lr` | 5e-5 | Learning rate |
+| `--batch-size` | 4 | Batch size |
+| `--steps` | 10000 | Training steps |
+
+## References
+
+- Paper: [Turning the Tide: Cross-Architecture Distillation for Diffusion Large Language Models](https://arxiv.org/abs/2604.26951)
+- Code: [PKU-YuanGroup/TIDE](https://github.com/PKU-YuanGroup/TIDE)
+- Project page: [pku-yuangroup.github.io/TIDE-Page](https://pku-yuangroup.github.io/TIDE-Page/)

--- a/examples/generative/llm/tide_dllm_distill/build.sh
+++ b/examples/generative/llm/tide_dllm_distill/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMG="${CVL_IMAGE:-cvlization/tide-dllm-distill:latest}"
+
+docker build --pull -t "$IMG" "$SCRIPT_DIR"

--- a/examples/generative/llm/tide_dllm_distill/example.yaml
+++ b/examples/generative/llm/tide_dllm_distill/example.yaml
@@ -1,0 +1,51 @@
+name: tide-dllm-distill
+capability: generative/llm
+modalities:
+  - text
+datasets:
+  - alpaca
+  - tulu-3-sft-mixture
+stability: experimental
+resources:
+  gpu: 1
+  vram_gb: 24  # Self-distillation ~5GB; full WeDLM-8B teacher ~20GB
+  cpu_cores: 4
+  disk_gb: 30
+image: cvlization/tide-dllm-distill:latest
+presets:
+  build:
+    script: build.sh
+    description: Build the Docker image
+  train:
+    script: train.sh
+    description: Run TIDE distillation training
+  predict:
+    script: predict.sh
+    description: Run inference with distilled model
+  test:
+    script: test.sh
+    description: Smoke test (self-distill 10 steps + predict)
+tags:
+  - dllm
+  - diffusion
+  - distillation
+  - tide
+  - bd3lm
+  - tidal
+  - comp-demo
+  - knowledge-distillation
+  - training
+  - inference
+  - pytorch
+tasks:
+  - text_generation
+  - knowledge_distillation
+frameworks:
+  - pytorch
+  - transformers
+description: >
+  TIDE cross-architecture distillation for diffusion LLMs. Distills knowledge
+  from a frozen teacher dLLM into a smaller student using TIDAL scheduling and
+  Complementary Demonstration (CompDemo). Based on "Turning the Tide" (arXiv
+  2604.26951). Supports Pipeline B (shared-tokenizer, e.g. WeDLM-8B teacher ->
+  Qwen3-0.6B-BD3LM student).

--- a/examples/generative/llm/tide_dllm_distill/predict.py
+++ b/examples/generative/llm/tide_dllm_distill/predict.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Inference with a TIDE-distilled diffusion language model.
+
+Loads a BD3LM checkpoint (from HuggingFace or a local path) and generates
+text via iterative block-diffusion demasking using the dllm library.
+
+Pre-trained TIDE checkpoints on HuggingFace:
+  TIDE-dllm/distill-WeDLM-TIDE_Shared   (Pipeline B, shared tokenizer)
+  TIDE-dllm/distill-LLaDA2-TIDE_Cross   (Pipeline A, cross tokenizer)
+
+The base (undistilled) model also works:
+  dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1
+"""
+
+import os
+import sys
+import logging
+import warnings
+
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+
+warnings.filterwarnings("ignore", category=UserWarning, module="torch")
+warnings.filterwarnings("ignore", category=FutureWarning)
+logging.basicConfig(level=logging.ERROR)
+for _name in ("transformers", "torch", "accelerate"):
+    logging.getLogger(_name).setLevel(logging.ERROR)
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import transformers
+import dllm
+
+try:
+    from cvlization.paths import get_output_dir, resolve_output_path
+    CVL_AVAILABLE = True
+except ImportError:
+    CVL_AVAILABLE = False
+
+    def get_output_dir():
+        d = os.path.join(os.getcwd(), "outputs")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    def resolve_output_path(path, base_dir):
+        if os.path.isabs(path):
+            return path
+        return os.path.join(base_dir, path)
+
+
+MODELS = {
+    "tide-wedlm-shared": {
+        "id": "TIDE-dllm/distill-WeDLM-TIDE_Shared",
+        "desc": "Pipeline B (shared tokenizer, TIDAL+CompDemo)",
+    },
+    "tide-llada-cross": {
+        "id": "TIDE-dllm/distill-LLaDA2-TIDE_Cross",
+        "desc": "Pipeline A (cross tokenizer, Reverse CALM)",
+    },
+    "base": {
+        "id": "dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1",
+        "desc": "Base Qwen3-0.6B BD3LM (undistilled)",
+    },
+}
+
+
+class _ModelArgs:
+    def __init__(self, path):
+        self.model_name_or_path = path
+
+
+def load_model(model_key_or_path: str):
+    """Load a BD3LM model and return (model, tokenizer, sampler)."""
+    if model_key_or_path in MODELS:
+        model_id = MODELS[model_key_or_path]["id"]
+    else:
+        model_id = model_key_or_path
+
+    print(f"Loading model: {model_id}")
+    args = _ModelArgs(model_id)
+    model = dllm.utils.get_model(model_args=args).eval()
+    tokenizer = dllm.utils.get_tokenizer(model_args=args)
+    sampler = dllm.core.samplers.BD3LMSampler(model=model, tokenizer=tokenizer)
+    return model, tokenizer, sampler
+
+
+def run_inference(sampler, tokenizer, prompt, steps=128,
+                  max_new_tokens=256, block_size=32, temperature=0.0):
+    messages = [[{"role": "user", "content": prompt}]]
+    inputs = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=True,
+    )
+    config = dllm.core.samplers.BD3LMSamplerConfig(
+        steps=steps,
+        max_new_tokens=max_new_tokens,
+        block_size=block_size,
+        temperature=temperature,
+        remasking="low_confidence",
+        right_shift_logits=False,
+    )
+    outputs = sampler.sample(inputs, config, return_dict=True)
+    seqs = dllm.utils.sample_trim(tokenizer, outputs.sequences.tolist(), inputs)
+    return seqs[0].strip() or "<empty>"
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Inference with TIDE-distilled dLLM",
+        epilog="""Available models:
+  tide-wedlm-shared : TIDE Pipeline B distilled (TIDAL+CompDemo)
+  tide-llada-cross  : TIDE Pipeline A distilled (Reverse CALM)
+  base              : Undistilled Qwen3-0.6B BD3LM
+  <path/or/hf-id>   : Any BD3LM-compatible checkpoint
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--model", default="base",
+                   help="Model key or HF ID / local path")
+    p.add_argument("--prompt", default="What is 2 + 2? Answer briefly.")
+    p.add_argument("--output", default=None)
+    p.add_argument("--format", choices=["txt", "json"], default="txt")
+    p.add_argument("--steps", type=int, default=128)
+    p.add_argument("--max-tokens", type=int, default=256)
+    p.add_argument("--block-size", type=int, default=32)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--verbose", action="store_true")
+    p.add_argument("--list-models", action="store_true")
+    args = p.parse_args()
+
+    if args.list_models:
+        print("Available models:")
+        for k, v in MODELS.items():
+            print(f"  {k:20} : {v['id']}")
+            print(f"  {' '*20}   {v['desc']}")
+        return 0
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, force=True)
+        for name in ("transformers", "torch", "accelerate"):
+            logging.getLogger(name).setLevel(logging.INFO)
+
+    transformers.set_seed(args.seed)
+
+    OUT = get_output_dir()
+    if args.output is None:
+        ext = "json" if args.format == "json" else "txt"
+        args.output = f"result.{ext}"
+    output_path = resolve_output_path(args.output, OUT)
+
+    model, tokenizer, sampler = load_model(args.model)
+
+    print(f"\nPrompt: {args.prompt[:100]}{'...' if len(args.prompt) > 100 else ''}")
+    print(f"Diffusion steps: {args.steps}, block_size: {args.block_size}")
+
+    text = run_inference(
+        sampler, tokenizer, args.prompt,
+        steps=args.steps, max_new_tokens=args.max_tokens,
+        block_size=args.block_size, temperature=args.temperature,
+    )
+
+    print("\n=== Output ===")
+    print(text)
+
+    # Save
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if args.format == "json":
+        data = {
+            "text": text, "model": args.model, "prompt": args.prompt,
+            "steps": args.steps, "max_tokens": args.max_tokens,
+            "block_size": args.block_size, "temperature": args.temperature,
+        }
+        out.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        out.write_text(text)
+    print(f"Output saved to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/generative/llm/tide_dllm_distill/predict.sh
+++ b/examples/generative/llm/tide_dllm_distill/predict.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="${CVL_WORK_DIR:-${WORK_DIR:-$(pwd)}}"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+IMG="${CVL_IMAGE:-cvlization/tide-dllm-distill:latest}"
+
+mkdir -p "$SCRIPT_DIR/outputs"
+
+docker run --rm --gpus=all --shm-size 16G \
+  ${CVL_CONTAINER_NAME:+--name "$CVL_CONTAINER_NAME"} \
+  --workdir /workspace \
+  --mount "type=bind,src=${SCRIPT_DIR},dst=/workspace" \
+  --mount "type=bind,src=${REPO_ROOT},dst=/cvlization_repo,readonly" \
+  --mount "type=bind,src=${HOME}/.cache/huggingface,dst=/root/.cache/huggingface" \
+  --env "PYTHONPATH=/cvlization_repo" \
+  --env "TORCH_COMPILE_DISABLE=1" \
+  --mount "type=bind,src=${WORK_DIR},dst=/mnt/cvl/workspace" \
+  --env "CVL_INPUTS=${CVL_INPUTS:-/mnt/cvl/workspace}" \
+  --env "CVL_OUTPUTS=${CVL_OUTPUTS:-/mnt/cvl/workspace}" \
+  ${HF_TOKEN:+-e HF_TOKEN=$HF_TOKEN} \
+  "$IMG" \
+  python predict.py "$@"

--- a/examples/generative/llm/tide_dllm_distill/requirements.txt
+++ b/examples/generative/llm/tide_dllm_distill/requirements.txt
@@ -1,0 +1,2 @@
+datasets>=2.18.0
+accelerate>=0.30.0

--- a/examples/generative/llm/tide_dllm_distill/test.sh
+++ b/examples/generative/llm/tide_dllm_distill/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Smoke test: self-distillation (10 steps) ==="
+"$SCRIPT_DIR/train.sh" \
+  --steps 10 \
+  --batch-size 2 \
+  --max-length 128 \
+  --max-samples 100 \
+  --log-interval 5 \
+  --save-interval 10
+
+echo ""
+echo "=== Smoke test: predict (64 tokens, 64 steps) ==="
+"$SCRIPT_DIR/predict.sh" \
+  --prompt "What is 2 + 2? Answer briefly." \
+  --steps 64 \
+  --max-tokens 64
+
+echo ""
+echo "Smoke test complete!"

--- a/examples/generative/llm/tide_dllm_distill/train.py
+++ b/examples/generative/llm/tide_dllm_distill/train.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""TIDE: Cross-Architecture Distillation for Diffusion LLMs.
+
+Implements TIDE-Shared distillation (Pipeline B): distill knowledge from a
+frozen teacher dLLM into a smaller student dLLM that shares the same tokenizer.
+
+Key components:
+- TIDAL: Dual-axis interpolation that gradually shifts from student
+  self-supervision to teacher-guided learning via cosine schedule.
+- CompDemo: Complementary demonstration that improves teacher signal quality
+  at high masking ratios by splitting masked positions into two subsets and
+  merging predictions from two forward passes.
+
+Reference: "Turning the Tide: Cross-Architecture Distillation for Diffusion
+Large Language Models" (arXiv 2604.26951)
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+try:
+    from cvlization.paths import get_output_dir
+    CVL_AVAILABLE = True
+except ImportError:
+    CVL_AVAILABLE = False
+
+    def get_output_dir():
+        d = os.path.join(os.getcwd(), "outputs")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+class TokenizedSFTDataset(Dataset):
+    """Tokenize an instruction-following dataset for masked diffusion training."""
+
+    def __init__(self, tokenizer, dataset_name="tatsu-lab/alpaca",
+                 max_length=512, max_samples=None):
+        from datasets import load_dataset
+
+        print(f"Loading dataset: {dataset_name}")
+        ds = load_dataset(dataset_name, split="train")
+        if max_samples:
+            ds = ds.select(range(min(max_samples, len(ds))))
+
+        pad_token_id = tokenizer.pad_token_id or tokenizer.eos_token_id
+        self.sequences = []
+
+        for item in ds:
+            text = _extract_text(item)
+            if not text:
+                continue
+
+            tokens = tokenizer.encode(
+                text, max_length=max_length, truncation=True,
+                add_special_tokens=True,
+            )
+            if len(tokens) < 16:
+                continue
+
+            # Pad to max_length
+            if len(tokens) < max_length:
+                tokens = tokens + [pad_token_id] * (max_length - len(tokens))
+
+            self.sequences.append(torch.tensor(tokens, dtype=torch.long))
+
+        print(f"Loaded {len(self.sequences)} sequences (max_length={max_length})")
+
+    def __len__(self):
+        return len(self.sequences)
+
+    def __getitem__(self, idx):
+        return self.sequences[idx]
+
+
+def _extract_text(item):
+    """Pull a training string from common HF dataset formats."""
+    if "instruction" in item:
+        parts = [item["instruction"]]
+        if item.get("input"):
+            parts.append(item["input"])
+        if item.get("output"):
+            parts.append(item["output"])
+        return "\n".join(parts)
+    if "text" in item:
+        return item["text"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# TIDAL scheduler
+# ---------------------------------------------------------------------------
+
+class TIDALScheduler:
+    """Dual-axis interpolation for distillation strength.
+
+    Lambda increases from lambda_init to lambda_max via cosine schedule:
+      early training -> lambda ~ lambda_init  (student learns from itself)
+      late training  -> lambda ~ lambda_max   (student learns from teacher)
+    """
+
+    def __init__(self, lambda_init=0.1, lambda_max=0.9, total_steps=10000):
+        self.lambda_init = lambda_init
+        self.lambda_max = lambda_max
+        self.total_steps = total_steps
+
+    def get_lambda(self, step):
+        progress = min(step / max(self.total_steps, 1), 1.0)
+        return (
+            self.lambda_init
+            + (self.lambda_max - self.lambda_init)
+            * (1 - math.cos(math.pi * progress)) / 2
+        )
+
+    @staticmethod
+    def timestep_weight(mask_ratio, sigma=0.15):
+        """Midrange timestep weighting: emphasise mask_ratio ~ 0.5."""
+        return math.exp(-((mask_ratio - 0.5) ** 2) / (2 * sigma ** 2))
+
+
+# ---------------------------------------------------------------------------
+# TIDAL loss
+# ---------------------------------------------------------------------------
+
+def compute_tidal_loss(student_logits, teacher_logits, mask,
+                       lambda_t, temperature=2.0):
+    """KL-based distillation loss with interpolated soft targets.
+
+    Args:
+        student_logits: (B, L, V)
+        teacher_logits: (B, L, V)
+        mask:           (B, L) bool – True for masked positions
+        lambda_t:       interpolation weight  (0=student, 1=teacher)
+        temperature:    softmax temperature
+    """
+    if mask.sum() == 0:
+        return torch.tensor(0.0, device=student_logits.device)
+
+    s = student_logits[mask]   # (N, V)
+    t = teacher_logits[mask]   # (N, V)
+
+    # Interpolated target  (detach student to avoid second-order gradients)
+    interp = ((1 - lambda_t) * s.detach() + lambda_t * t) / temperature
+    target = F.softmax(interp, dim=-1)
+
+    log_probs = F.log_softmax(s / temperature, dim=-1)
+    return F.kl_div(log_probs, target, reduction="batchmean") * (temperature ** 2)
+
+
+# ---------------------------------------------------------------------------
+# CompDemo – Complementary Demonstration
+# ---------------------------------------------------------------------------
+
+def comp_demo_teacher_forward(teacher, input_ids, original_ids, mask,
+                              mask_token_id):
+    """Two-pass teacher inference with complementary mask splits.
+
+    Splits masked positions into A/B subsets.  Pass 1 reveals A as context and
+    collects predictions for B.  Pass 2 reveals B and collects for A.  Merged
+    logits give each position ~50 % extra revealed context.
+    """
+    if mask.sum() == 0:
+        with torch.no_grad():
+            return teacher(input_ids).logits
+
+    device = input_ids.device
+    mask_idx = mask.nonzero(as_tuple=False)  # (N, 2)
+    n = mask_idx.shape[0]
+    perm = torch.randperm(n, device=device)
+    half = n // 2
+
+    # Build subset masks
+    subset_a = torch.zeros_like(mask)
+    subset_b = torch.zeros_like(mask)
+    if half > 0:
+        a_idx = mask_idx[perm[:half]]
+        subset_a[a_idx[:, 0], a_idx[:, 1]] = True
+    if n - half > 0:
+        b_idx = mask_idx[perm[half:]]
+        subset_b[b_idx[:, 0], b_idx[:, 1]] = True
+
+    # Pass 1: reveal A, keep B masked  →  good logits for B
+    inp1 = original_ids.clone()
+    inp1[subset_b] = mask_token_id
+
+    # Pass 2: reveal B, keep A masked  →  good logits for A
+    inp2 = original_ids.clone()
+    inp2[subset_a] = mask_token_id
+
+    with torch.no_grad():
+        logits1 = teacher(inp1).logits
+        logits2 = teacher(inp2).logits
+
+    merged = logits1.clone()
+    merged[subset_a] = logits2[subset_a]
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Masking
+# ---------------------------------------------------------------------------
+
+def apply_random_masking(input_ids, mask_token_id, pad_token_id):
+    """Token-level masking with uniform mask-ratio sampling."""
+    B, L = input_ids.shape
+    device = input_ids.device
+
+    non_pad = input_ids != pad_token_id
+    ratios = torch.rand(B, 1, device=device)
+    mask = (torch.rand(B, L, device=device) < ratios) & non_pad
+
+    masked = input_ids.clone()
+    masked[mask] = mask_token_id
+    return masked, mask, ratios.mean().item()
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+def train(args):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    torch.manual_seed(args.seed)
+
+    # Tokenizer (shared between teacher & student in Pipeline B)
+    print(f"Loading tokenizer from: {args.student_model}")
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.student_model, trust_remote_code=True,
+    )
+    mask_token_id = tokenizer.mask_token_id
+    if mask_token_id is None:
+        mask_token_id = tokenizer.convert_tokens_to_ids("[MASK]")
+    pad_token_id = tokenizer.pad_token_id or tokenizer.eos_token_id
+    print(f"  mask_token={mask_token_id}  pad_token={pad_token_id}")
+
+    # Student (trainable)
+    print(f"Loading student: {args.student_model}")
+    student = AutoModelForMaskedLM.from_pretrained(
+        args.student_model, dtype=torch.bfloat16, trust_remote_code=True,
+    ).to(device)
+    student.train()
+
+    # Teacher (frozen)
+    teacher_id = args.teacher_model or args.student_model
+    print(f"Loading teacher: {teacher_id}")
+    if teacher_id == args.student_model:
+        print("  (self-distillation mode – student used as its own teacher)")
+    teacher = AutoModelForMaskedLM.from_pretrained(
+        teacher_id, dtype=torch.bfloat16, trust_remote_code=True,
+    ).to(device)
+    teacher.eval()
+    for p in teacher.parameters():
+        p.requires_grad = False
+
+    # Data
+    dataset = TokenizedSFTDataset(
+        tokenizer, dataset_name=args.dataset,
+        max_length=args.max_length, max_samples=args.max_samples,
+    )
+    loader = DataLoader(
+        dataset, batch_size=args.batch_size, shuffle=True,
+        drop_last=True, num_workers=0,
+    )
+
+    # TIDAL
+    tidal = TIDALScheduler(
+        lambda_init=args.lambda_init, lambda_max=args.lambda_max,
+        total_steps=args.steps,
+    )
+
+    # Optimiser & scheduler
+    optimizer = torch.optim.AdamW(
+        student.parameters(), lr=args.lr, weight_decay=args.weight_decay,
+    )
+    lr_sched = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=args.steps, eta_min=args.lr * 0.1,
+    )
+
+    out_dir = args.output_dir
+    os.makedirs(out_dir, exist_ok=True)
+
+    print(f"\nStarting TIDE distillation")
+    print(f"  steps={args.steps}  batch_size={args.batch_size}  lr={args.lr}")
+    print(f"  TIDAL lambda: {args.lambda_init} -> {args.lambda_max}")
+    print(f"  CompDemo: {args.use_comp_demo}")
+    print(f"  temperature={args.temperature}  "
+          f"ce_weight={args.ce_weight}  tidal_weight={args.tidal_weight}")
+    print()
+
+    step = 0
+    t0 = time.time()
+    data_iter = iter(loader)
+    acc_loss = acc_ce = acc_td = 0.0
+
+    while step < args.steps:
+        try:
+            batch = next(data_iter)
+        except StopIteration:
+            data_iter = iter(loader)
+            batch = next(data_iter)
+
+        input_ids = batch.to(device)
+        masked_ids, mask, mask_ratio = apply_random_masking(
+            input_ids, mask_token_id, pad_token_id,
+        )
+
+        # Teacher logits
+        if args.use_comp_demo:
+            t_logits = comp_demo_teacher_forward(
+                teacher, masked_ids, input_ids, mask, mask_token_id,
+            )
+        else:
+            with torch.no_grad():
+                t_logits = teacher(masked_ids).logits
+
+        # Student forward
+        s_logits = student(masked_ids).logits
+
+        # CE loss on masked positions
+        if mask.sum() > 0:
+            ce_loss = F.cross_entropy(s_logits[mask], input_ids[mask])
+        else:
+            ce_loss = torch.tensor(0.0, device=device)
+
+        # TIDAL loss
+        lam = tidal.get_lambda(step)
+        tw = tidal.timestep_weight(mask_ratio)
+        td_loss = compute_tidal_loss(
+            s_logits, t_logits, mask, lam, temperature=args.temperature,
+        )
+
+        loss = args.ce_weight * ce_loss + args.tidal_weight * tw * td_loss
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        if args.max_grad_norm > 0:
+            torch.nn.utils.clip_grad_norm_(student.parameters(),
+                                           args.max_grad_norm)
+        optimizer.step()
+        lr_sched.step()
+
+        acc_loss += loss.item()
+        acc_ce += ce_loss.item()
+        acc_td += td_loss.item()
+        step += 1
+
+        if step % args.log_interval == 0 or step == args.steps:
+            n = args.log_interval
+            lr = lr_sched.get_last_lr()[0]
+            print(
+                f"step {step}/{args.steps} | "
+                f"loss {acc_loss/n:.4f} "
+                f"(CE {acc_ce/n:.4f}  TIDAL {acc_td/n:.4f}) | "
+                f"lambda {lam:.3f} | lr {lr:.2e} | "
+                f"{time.time()-t0:.1f}s"
+            )
+            acc_loss = acc_ce = acc_td = 0.0
+
+        if step % args.save_interval == 0 or step == args.steps:
+            ckpt = os.path.join(out_dir, f"checkpoint-{step}")
+            print(f"  saving -> {ckpt}")
+            student.save_pretrained(ckpt)
+            tokenizer.save_pretrained(ckpt)
+            with open(os.path.join(ckpt, "training_state.json"), "w") as f:
+                json.dump({"step": step, "lambda": lam,
+                           "args": {k: str(v) for k, v in vars(args).items()}},
+                          f, indent=2)
+
+    print(f"\nTraining complete in {time.time()-t0:.1f}s")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    p = argparse.ArgumentParser(description="TIDE distillation for dLLMs")
+
+    # Models
+    p.add_argument("--student-model", default="dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1",
+                   help="Student model HF ID")
+    p.add_argument("--teacher-model", default=None,
+                   help="Teacher model HF ID (default: same as student)")
+
+    # Data
+    p.add_argument("--dataset", default="tatsu-lab/alpaca",
+                   help="HuggingFace dataset name")
+    p.add_argument("--max-length", type=int, default=512)
+    p.add_argument("--max-samples", type=int, default=None,
+                   help="Cap on training samples (None=all)")
+
+    # Training
+    p.add_argument("--steps", type=int, default=10000)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--lr", type=float, default=5e-5)
+    p.add_argument("--weight-decay", type=float, default=0.01)
+    p.add_argument("--max-grad-norm", type=float, default=1.0)
+    p.add_argument("--seed", type=int, default=42)
+
+    # TIDAL
+    p.add_argument("--lambda-init", type=float, default=0.1)
+    p.add_argument("--lambda-max", type=float, default=0.9)
+    p.add_argument("--temperature", type=float, default=2.0)
+    p.add_argument("--ce-weight", type=float, default=1.0)
+    p.add_argument("--tidal-weight", type=float, default=1.0)
+
+    # CompDemo
+    p.add_argument("--use-comp-demo", action="store_true", default=True)
+    p.add_argument("--no-comp-demo", dest="use_comp_demo",
+                   action="store_false")
+
+    # Output
+    p.add_argument("--output-dir", default=None)
+    p.add_argument("--log-interval", type=int, default=10)
+    p.add_argument("--save-interval", type=int, default=1000)
+
+    args = p.parse_args()
+    if args.output_dir is None:
+        args.output_dir = get_output_dir()
+    return train(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/generative/llm/tide_dllm_distill/train.sh
+++ b/examples/generative/llm/tide_dllm_distill/train.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="${CVL_WORK_DIR:-${WORK_DIR:-$(pwd)}}"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+IMG="${CVL_IMAGE:-cvlization/tide-dllm-distill:latest}"
+
+mkdir -p "$SCRIPT_DIR/outputs"
+
+docker run --rm --gpus=all --shm-size 16G \
+  ${CVL_CONTAINER_NAME:+--name "$CVL_CONTAINER_NAME"} \
+  --workdir /workspace \
+  --mount "type=bind,src=${SCRIPT_DIR},dst=/workspace" \
+  --mount "type=bind,src=${REPO_ROOT},dst=/cvlization_repo,readonly" \
+  --mount "type=bind,src=${HOME}/.cache/huggingface,dst=/root/.cache/huggingface" \
+  --env "PYTHONPATH=/cvlization_repo" \
+  --env "PYTHONUNBUFFERED=1" \
+  --mount "type=bind,src=${WORK_DIR},dst=/mnt/cvl/workspace" \
+  --env "CVL_INPUTS=${CVL_INPUTS:-/mnt/cvl/workspace}" \
+  --env "CVL_OUTPUTS=${CVL_OUTPUTS:-/mnt/cvl/workspace}" \
+  ${HF_TOKEN:+-e HF_TOKEN=$HF_TOKEN} \
+  ${WANDB_API_KEY:+-e WANDB_API_KEY=$WANDB_API_KEY} \
+  ${CUDA_VISIBLE_DEVICES:+--env "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"} \
+  "$IMG" \
+  python train.py "$@"


### PR DESCRIPTION
## Summary

- Adds `examples/generative/llm/tide_dllm_distill/` implementing the TIDE recipe ([arXiv 2604.26951](https://arxiv.org/abs/2604.26951))
- Self-contained training script implementing TIDAL scheduling and Complementary Demonstration (CompDemo) for shared-tokenizer dLLM distillation (Pipeline B)
- Inference script using pre-trained TIDE-distilled checkpoints from HuggingFace (`TIDE-dllm/distill-WeDLM-TIDE_Shared`, `TIDE-dllm/distill-LLaDA2-TIDE_Cross`)
- Dockerized with standard CVlization conventions (build/train/predict/test presets)

## Test plan

- [x] Docker image builds successfully
- [x] Self-distillation smoke test passes (10 steps, loss 5.37→4.59, TIDAL lambda 0.38→0.88)
- [x] Inference smoke test passes (base Qwen3-0.6B-BD3LM: "What is 2+2?" → "4")
- [ ] Full distillation with WeDLM-8B teacher (requires ≥24GB VRAM)

Closes #14